### PR TITLE
Fix parameterization spelling

### DIFF
--- a/R/invgamma.R
+++ b/R/invgamma.R
@@ -5,7 +5,7 @@
 #'
 #' The inverse gamma distribution with parameters shape and rate has density
 #' \deqn{f(x) = \frac{rate^{shape}}{\Gamma(shape)} x^{-1-shape} e^{-rate/x}} it
-#' is the inverse of the standard gamma parameterzation in R. If \eqn{X \sim
+#' is the inverse of the standard gamma parameterization in R. If \eqn{X \sim
 #' InvGamma(shape, rate)}, \deqn{E[X] = \frac{rate}{shape-1}} when \eqn{shape > 1}
 #' and \deqn{Var(X) = \frac{rate^2}{(shape - 1)^2(shape - 2)}} for \eqn{shape > 2}.
 #'

--- a/man/invgamma.Rd
+++ b/man/invgamma.Rd
@@ -42,7 +42,7 @@ the inverse gamma distribution.
 \details{
 The inverse gamma distribution with parameters shape and rate has density
 \deqn{f(x) = \frac{rate^{shape}}{\Gamma(shape)} x^{-1-shape} e^{-rate/x}} it
-is the inverse of the standard gamma parameterzation in R. If \eqn{X \sim
+is the inverse of the standard gamma parameterization in R. If \eqn{X \sim
 InvGamma(shape, rate)}, \deqn{E[X] = \frac{rate}{shape-1}} when \eqn{shape > 1}
 and \deqn{Var(X) = \frac{rate^2}{(shape - 1)^2(shape - 2)}} for \eqn{shape > 2}.
 


### PR DESCRIPTION
## Summary
- fix typo in `R/invgamma.R`
- update generated docs accordingly

## Testing
- `Rscript -e "roxygen2::roxygenise()"` *(fails: command not found)*
- `R CMD build .` *(fails: command not found)*
- `Rscript -e "devtools::test()"` *(fails: command not found)*